### PR TITLE
Add tests and remove auto-use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv/
 *.pyc
 *.egg-info/
+.pytest*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
 
 jobs:
   include:
+    - stage: Python 3.5 - Django 2.2
+      dist: xenial
+      python: "3.5"
+      env:
+        - DJANGO="==2.2.*"
+
     - stage: Python 3.6 - Django 2.2
       dist: xenial
       python: "3.6"
@@ -56,6 +62,8 @@ matrix:
       env: DJANGO="==2.2.*"
     - python: "3.4"
       env: DJANGO="master"
+    - python: "3.5"  # We need to use xenial here instead of trusty
+      env: DJANGO="==2.2.*"
     - python: "3.5"
       env: DJANGO="master"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # pytest-django-queries
 Generate performance rapports from your django database performance tests.
 
+## Usage
+Simply install `pytest-django-queries`, write your pytest tests and mark any
+test that should be counted or use the `count_queries` fixture.
+
+```python
+import pytest
+
+
+@pytest.mark.count_queries
+def test_query_performances():
+    Model.objects.all()
+
+
+# Or...
+def test_another_query_performances(count_queries):
+    Model.objects.all()
+```
+
 ## Integrating with GitHub
 
 ## Testing locally

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
-# pytest-django-queries
-Generate performance rapports from your django database performance tests.
+<div align='center'>
+  <h1>pytest-django-queries</h1>
+  <p>Generate performance rapports from your django database performance tests.</p>
+  <p>
+    <a href='https://travis-ci.org/NyanKiyoshi/pytest-django-queries/'>
+      <img src='https://travis-ci.org/NyanKiyoshi/pytest-django-queries.svg?branch=master' alt='Requirement Status' />
+    </a>
+    <a href='https://codecov.io/gh/NyanKiyoshi/pytest-django-queries'>
+      <img src='https://codecov.io/gh/NyanKiyoshi/pytest-django-queries/branch/master/graph/badge.svg' alt='Coverage Status' />
+    </a>
+    <a href='https://pypi.python.org/pypi/pytest-django-queries'>
+      <img src='https://img.shields.io/pypi/v/pytest-django-queries.svg' alt='Version' />
+    </a>
+    <a href='https://requires.io/github/NyanKiyoshi/pytest-django-queries/requirements/?branch=master'>
+      <img src='https://requires.io/github/NyanKiyoshi/pytest-django-queries/requirements.svg?branch=master' alt='Requirement Status' />
+    </a>
+  </p>
+  <p>
+    <a href='https://github.com/pytest-dev/pytest-cov/compare/v0.0.0...master'>
+      <img src='https://img.shields.io/github/commits-since/NyanKiyoshi/pytest-django-queries/v0.0.0.svg' alt='Commits since latest release' />
+    </a>
+    <a href='https://pypi.python.org/pypi/pytest-django-queries'>
+      <img src='https://img.shields.io/pypi/pyversions/pytest-django-queries.svg' alt='Supported versions' />
+    </a>
+    <a href='https://pypi.python.org/pypi/pytest-django-queries'>
+      <img src='https://img.shields.io/pypi/implementation/pytest-django-queries.svg' alt='Supported implementations' />
+    </a>
+  </p>
+</div>
 
 ## Usage
 Simply install `pytest-django-queries`, write your pytest tests and mark any

--- a/pytest_django_queries/plugin.py
+++ b/pytest_django_queries/plugin.py
@@ -1,15 +1,15 @@
 import json
 from datetime import datetime
 from os import environ
-from threading import RLock
 
 import pytest
 from django.test.utils import CaptureQueriesContext
 
-lock = RLock()
-_test_data = {}
-
+# Defines the environment variable name
+# for overriding the export path
 ENV_QUERY_SAVE_PATH = 'PYTEST_QUERIES_SAVE_PATH'
+
+# Defines the plugin marker name
 PYTEST_QUERY_COUNT_MARKER = 'count_queries'
 
 
@@ -24,30 +24,49 @@ def _get_save_path():
         '.pytest-queries-{}.json'.format(_get_date_now()))
 
 
-def _add_test_to_data(module_name, test_name, query_count):
-    with lock:
-        _test_data.setdefault(module_name, {})[test_name] = {
-            'query-count': query_count}
+def _set_session(config, new_session):
+    config.pytest_django_queries_session = new_session
 
 
-def pytest_load_initial_conftests(early_config, parser, args):
+def _get_session(request):
+    return request.config.pytest_django_queries_session
+
+
+class _Session(object):
+    def __init__(self):
+        self._data = {}
+
+    def add_entry(self, module_name, test_name, query_count):
+        module_data = self._data.setdefault(module_name, {})
+        module_data[test_name] = {'query-count': query_count}
+
+    def save_json(self):
+        with open(_get_save_path(), 'w') as fp:
+            json.dump(self._data, fp, indent=2)
+
+    def finish(self):
+        """Serialize and export the test data if performance tests were run."""
+
+        if not self._data:
+            return
+
+        self.save_json()
+
+
+@pytest.mark.tryfirst
+def pytest_configure(config):
     """Append the plugin markers to the pytest configuration."""
     config_line = (
        '%s: Mark the test as to have their queries counted.'
        '' % PYTEST_QUERY_COUNT_MARKER)
-    early_config.addinivalue_line('markers', config_line)
+    config.addinivalue_line('markers', config_line)
+    _set_session(config, _Session())
 
 
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_unconfigure(config):
-    """Serialize and export the test data if performance tests were run."""
+@pytest.hookimpl(hookwrapper=True)
+def pytest_sessionfinish(session, exitstatus):
+    _get_session(session).finish()
     yield
-
-    if not _test_data:
-        return
-
-    with open(_get_save_path(), 'w') as w:
-        json.dump(_test_data, w, indent=2)
 
 
 @pytest.fixture(autouse=True)
@@ -70,4 +89,4 @@ def count_queries(request):
 
     module = request.node.module.__name__
     bench_name = request.node.name
-    _add_test_to_data(module, bench_name, query_count)
+    _get_session(request).add_entry(module, bench_name, query_count)

--- a/pytest_django_queries/plugin.py
+++ b/pytest_django_queries/plugin.py
@@ -17,7 +17,7 @@ def _get_date_now():
     return datetime.now().strftime('%m-%d-%Y-%H-%M-%S')
 
 
-def _get_save_path():
+def _make_save_path():
     """Retrieve the save path from the environment variable value or make one
     using the current date and time."""
     return environ.get(ENV_QUERY_SAVE_PATH, None) or (
@@ -41,7 +41,7 @@ class _Session(object):
         module_data[test_name] = {'query-count': query_count}
 
     def save_json(self):
-        with open(_get_save_path(), 'w') as fp:
+        with open(_make_save_path(), 'w') as fp:
             json.dump(self._data, fp, indent=2)
 
     def finish(self):

--- a/pytest_django_queries/plugin.py
+++ b/pytest_django_queries/plugin.py
@@ -9,13 +9,18 @@ from django.test.utils import CaptureQueriesContext
 lock = RLock()
 _test_data = {}
 
+ENV_QUERY_SAVE_PATH = 'PYTEST_QUERIES_SAVE_PATH'
+PYTEST_QUERY_COUNT_MARKER = 'count_queries'
+
 
 def _get_date_now():
     return datetime.now().strftime('%m-%d-%Y-%H-%M-%S')
 
 
 def _get_save_path():
-    return environ.get('PYTEST_QUERIES_SAVE_PATH', None) or (
+    """Retrieve the save path from the environment variable value or make one
+    using the current date and time."""
+    return environ.get(ENV_QUERY_SAVE_PATH, None) or (
         '.pytest-queries-{}.json'.format(_get_date_now()))
 
 
@@ -25,16 +30,38 @@ def _add_test_to_data(module_name, test_name, query_count):
             'query-count': query_count}
 
 
+def pytest_load_initial_conftests(early_config, parser, args):
+    """Append the plugin markers to the pytest configuration."""
+    config_line = (
+       '%s: Mark the test as to have their queries counted.'
+       '' % PYTEST_QUERY_COUNT_MARKER)
+    early_config.addinivalue_line('markers', config_line)
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_unconfigure(config):
+    """Serialize and export the test data if performance tests were run."""
     yield
+
+    if not _test_data:
+        return
 
     with open(_get_save_path(), 'w') as w:
         json.dump(_test_data, w, indent=2)
 
 
-@pytest.fixture(autouse=True, scope='function')
-def trap_queries(request):
+@pytest.fixture(autouse=True)
+def _pytest_query_marker(request):
+    """Use the fixture to count the queries on the current node if it's
+    marked with 'count_queries'."""
+    marker = request.node.get_closest_marker(PYTEST_QUERY_COUNT_MARKER)
+    if marker:
+        request.getfixturevalue('count_queries')
+
+
+@pytest.fixture
+def count_queries(request):
+    """Wrap a test to count the number of performed queries."""
     from django.db import connection
 
     with CaptureQueriesContext(connection) as context:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from os.path import isfile
 from setuptools import setup
 
-REQUIREMENTS = ['pytest', 'django']
+REQUIREMENTS = ['pytest', 'django', 'freezegun']
 TEST_REQUIREMENTS = []
 
 
@@ -23,7 +23,7 @@ setup(
                 'performance tests.',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='0.0.0',
+    version='0.1.0rc1',
     packages=['pytest_django_queries'],
     include_package_data=True,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Pytest'
+        'Framework :: Pytest',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules'],
     install_requires=REQUIREMENTS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pytest_django_queries.plugin import ENV_QUERY_SAVE_PATH
+
+pytest_plugins = 'pytester'
+
+
+@pytest.fixture()
+def temp_results(testdir, monkeypatch):
+    # Make a dummy path where to save the results
+    # and override the dump path by setting the PYTEST_QUERIES_SAVE_PATH
+    # environment variable
+    results_path = testdir.tmpdir.join('results.json')
+    monkeypatch.setenv(ENV_QUERY_SAVE_PATH, str(results_path))
+
+    return testdir, results_path

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,4 @@
-import pytest
+import json
 
 DUMMY_TEST_QUERY = """
     import pytest
@@ -33,6 +33,13 @@ def test_fixture_is_invoked_when_marked(temp_results):
 
     # Ensure the results file was created
     assert results_path.check()
+    assert json.load(results_path) == {
+      "test_fixture_is_invoked_when_marked": {
+        "test_count_db_query_number": {
+          "query-count": 2
+        }
+      }
+    }
 
 
 def test_plugin_exports_nothing_if_empty(temp_results):
@@ -78,6 +85,13 @@ def test_plugin_exports_results_even_when_test_fails(temp_results):
 
     # Ensure the results file was created
     assert results_path.check()
+    assert json.load(results_path) == {
+      "test_plugin_exports_results_even_when_test_fails": {
+        "test_failure": {
+          "query-count": 0
+        }
+      }
+    }
 
 
 def test_marker_message(testdir):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,2 +1,86 @@
-def test_pass():
-    pass
+import pytest
+
+DUMMY_TEST_QUERY = """
+    import pytest
+    
+    @pytest.mark.count_queries
+    def test_count_db_query_number():
+        from django.db import connection
+        
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT date('now');")
+            cursor.execute("SELECT 1;")
+            cursor.fetchone()
+"""
+
+# Check that the plugin has been properly installed before proceeding
+assert pytest.config.pluginmanager.hasplugin('django_queries')
+
+
+def test_fixture_is_invoked_when_marked(temp_results):
+    """Ensure marking a test is actually calling the fixture."""
+    testdir, results_path = temp_results
+
+    # Run a dummy test that performs queries
+    # and triggers a counting of the query number
+    testdir.makepyfile(DUMMY_TEST_QUERY)
+    results = testdir.runpytest()
+
+    # Ensure the tests have passed
+    results.assert_outcomes(1, 0, 0)
+
+    # Ensure the results file was created
+    assert results_path.check()
+
+
+def test_plugin_exports_nothing_if_empty(temp_results):
+    """Ensure the plugin does not export any results if no performance
+    tests were run."""
+
+    testdir, results_path = temp_results
+
+    # Run a dummy test that performs queries
+    # and triggers a counting of the query number
+    testdir.makepyfile("""
+        def test_nothing():
+            pass
+    """)
+    results = testdir.runpytest()
+
+    # Ensure the tests have passed
+    results.assert_outcomes(1, 0, 0)
+
+    # Ensure the results file was not created
+    assert not results_path.check()
+
+
+def test_plugin_exports_results_even_when_test_fails(temp_results):
+    """Ensure the plugin does not export any results if no performance
+    tests were run."""
+
+    testdir, results_path = temp_results
+
+    # Run a dummy test that performs queries
+    # and triggers a counting of the query number
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.count_queries
+        def test_failure():
+            assert 0
+    """)
+    results = testdir.runpytest()
+
+    # Ensure the tests have passed
+    results.assert_outcomes(0, 0, 1)
+
+    # Ensure the results file was created
+    assert results_path.check()
+
+
+def test_marker_message(testdir):
+    """Ensure the custom markers configuration is added to pytest."""
+    result = testdir.runpytest('--markers')
+    result.stdout.fnmatch_lines([
+        '@pytest.mark.count_queries: '
+        'Mark the test as to have their queries counted.'])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,7 @@
 import json
 
+from freezegun import freeze_time
+
 DUMMY_TEST_QUERY = """
     import pytest
     
@@ -100,3 +102,12 @@ def test_marker_message(testdir):
     result.stdout.fnmatch_lines([
         '@pytest.mark.count_queries: '
         'Mark the test as to have their queries counted.'])
+
+
+@freeze_time('2012-01-14 03:21:34')
+def test_get_save_path_returns_filename_with_date():
+    from pytest_django_queries.plugin import _make_save_path
+
+    filename = _make_save_path()
+    assert filename.startswith('.pytest-queries-')
+    assert filename.endswith('-01-14-2012-03-21-34.json')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,8 +13,10 @@ DUMMY_TEST_QUERY = """
             cursor.fetchone()
 """
 
-# Check that the plugin has been properly installed before proceeding
-assert pytest.config.pluginmanager.hasplugin('django_queries')
+
+def test_plugin_is_loaded(request):
+    # Check that the plugin has been properly installed before proceeding
+    assert request.config.pluginmanager.hasplugin('django_queries')
 
 
 def test_fixture_is_invoked_when_marked(temp_results):


### PR DESCRIPTION
This PR adds testing of the main features and removes the auto-use of the plugin; instead, the user will have to do a `@pytest.mark.count_queries` or use the `count_queries` fixture.