### PR TITLE
Update dependencies of Python 3.5 on django 2.2 and force fixing the 2.7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
 
 jobs:
   include:
+    - stage: Python 3.5 - Django 2.2
+      dist: xenial
+      python: "3.5"
+      env:
+        - DJANGO="==2.2.*"
+
     - stage: Python 3.6 - Django 2.2
       dist: xenial
       python: "3.6"
@@ -56,6 +62,8 @@ matrix:
       env: DJANGO="==2.2.*"
     - python: "3.4"
       env: DJANGO="master"
+    - python: "3.5"  # We need to use xenial here instead of trusty
+      env: DJANGO="==2.2.*"
     - python: "3.5"
       env: DJANGO="master"
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 from os.path import isfile
 from setuptools import setup
 
-REQUIREMENTS = ['pytest', 'django']
+REQUIREMENTS = [
+    'pluggy==0.11.0', 'pytest', 'django>=1.0,<3.0']
 TEST_REQUIREMENTS = []
 
 


### PR DESCRIPTION
- A bad release of pluggy broke randomly the 2.7 builds, the version is now tight to 1.11 with this fix applied https://github.com/pytest-dev/pluggy/issues/205.
- Python 3.5 is now ran into xenial to have a more recent version of sqlite3 and of python 3.5 which was failing to build randomly as well.