### PR TITLE
Add the base cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ venv/
 .pytest*
 .coverage
 *cov/
+*.html
 dist/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align='center'>
   <h1>pytest-django-queries</h1>
-  <p>Generate performance rapports from your django database performance tests.</p>
+  <p>Generate performance rapports from your django database performance tests
+  (inspired by <a href='https://coverage.readthedocs.io/en/v4.5.x/'>coverage.py</a>).</p>
   <p>
     <a href='https://travis-ci.org/NyanKiyoshi/pytest-django-queries/'>
       <img src='https://travis-ci.org/NyanKiyoshi/pytest-django-queries.svg?branch=master' alt='Requirement Status' />
@@ -46,6 +47,11 @@ def test_another_query_performances(count_queries):
     Model.objects.all()
 ```
 
+Each test file and/or package is considered as a category. Each test inside a "category"
+compose its data, see [Visualising Results](#visualising-results) for more details.
+
+<!-- TODO: insert a graphic here to explain how it works -->
+
 ## Integrating with GitHub
 
 ## Testing locally
@@ -57,6 +63,40 @@ Note: to override the save path, set the `PYTEST_QUERIES_SAVE_PATH`
 environment variable to any given valid path.
 
 ## Visualising Results
+You can generate a table from the tests results by using the `show` command:
+```shell
+django-queries show <json file>
+```
+
+You will get something like this to represent the results:
+```shell
++---------+-------------------------+
+| Module  |          Tests          |
++---------+-------------------------+
+| module1 | +-----------+---------+ |
+|         | | Test Name | Queries | |
+|         | +-----------+---------+ |
+|         | |   test1   |    0    | |
+|         | +-----------+---------+ |
+|         | |   test2   |    1    | |
+|         | +-----------+---------+ |
++---------+-------------------------+
+| module2 | +-----------+---------+ |
+|         | | Test Name | Queries | |
+|         | +-----------+---------+ |
+|         | |   test1   |   123   | |
+|         | +-----------+---------+ |
++---------+-------------------------+
+| module3 |                         |
++---------+-------------------------+
+```
+
+## Exporting the results (HTML)
+For a nicer presentation, use the `html` command, to export the results as HTML.
+```shell
+django-queries html <json file> > results.html
+```
+<!-- todo: add example page link -->
 
 ## Comparing results
 

--- a/pytest_django_queries/cli.py
+++ b/pytest_django_queries/cli.py
@@ -1,0 +1,34 @@
+import json
+
+import click
+
+
+class JsonFileParamType(click.File):
+    name = 'integer'
+
+    def convert(self, value, param, ctx):
+        fp = super(JsonFileParamType, self).convert(value, param, ctx)
+        if fp is not None:
+            try:
+                return json.load(fp)
+            except ValueError as e:
+                self.fail(
+                    'The file is not valid json: %s' % str(e),
+                    param,
+                    ctx)
+
+
+@click.group()
+def main():
+    """Command line tool for pytest-django-queries."""
+
+
+@main.command()
+@click.argument('input_file', type=JsonFileParamType('r'))
+def view(input_file):
+    """View a rapport."""
+    click.echo()
+
+
+if __name__ == '__main__':
+    main()

--- a/pytest_django_queries/cli.py
+++ b/pytest_django_queries/cli.py
@@ -12,17 +12,16 @@ class JsonFileParamType(click.File):
 
     def convert(self, value, param, ctx):
         fp = super(JsonFileParamType, self).convert(value, param, ctx)
-        if fp is not None:
-            try:
-                loaded = json.load(fp)
-                if type(loaded) is not dict:
-                    self.fail('The file is not a dictionary', param, ctx)
-                return loaded
-            except ValueError as e:
-                self.fail(
-                    'The file is not valid json: %s' % str(e),
-                    param,
-                    ctx)
+        try:
+            loaded = json.load(fp)
+            if type(loaded) is not dict:
+                self.fail('The file is not a dictionary', param, ctx)
+            return loaded
+        except ValueError as e:
+            self.fail(
+                'The file is not valid json: %s' % str(e),
+                param,
+                ctx)
 
 
 class Jinja2TemplateFile(click.File):
@@ -30,14 +29,13 @@ class Jinja2TemplateFile(click.File):
 
     def convert(self, value, param, ctx):
         fp = super(Jinja2TemplateFile, self).convert(value, param, ctx)
-        if fp is not None:
-            try:
-                return Template(fp.read())
-            except jinja_exceptions.TemplateError as e:
-                self.fail(
-                    'The file is not a valid jinja2 template: %s' % str(e),
-                    param,
-                    ctx)
+        try:
+            return Template(fp.read())
+        except jinja_exceptions.TemplateError as e:
+            self.fail(
+                'The file is not a valid jinja2 template: %s' % str(e),
+                param,
+                ctx)
 
 
 @click.group()

--- a/pytest_django_queries/cli.py
+++ b/pytest_django_queries/cli.py
@@ -2,6 +2,8 @@ import json
 
 import click
 
+from pytest_django_queries.tables import print_entries
+
 
 class JsonFileParamType(click.File):
     name = 'integer'
@@ -10,7 +12,10 @@ class JsonFileParamType(click.File):
         fp = super(JsonFileParamType, self).convert(value, param, ctx)
         if fp is not None:
             try:
-                return json.load(fp)
+                loaded = json.load(fp)
+                if type(loaded) is not dict:
+                    self.fail('The file is not a dictionary', param, ctx)
+                return loaded
             except ValueError as e:
                 self.fail(
                     'The file is not valid json: %s' % str(e),
@@ -25,9 +30,15 @@ def main():
 
 @main.command()
 @click.argument('input_file', type=JsonFileParamType('r'))
-def view(input_file):
-    """View a rapport."""
-    click.echo()
+@click.option(
+    '--html',
+    is_flag=True, help='Render the results as HTML instead of a raw table.')
+def view(input_file, html):
+    """View a given rapport."""
+    if not html:
+        print_entries(input_file)
+        return
+    raise NotImplementedError
 
 
 if __name__ == '__main__':

--- a/pytest_django_queries/cli.py
+++ b/pytest_django_queries/cli.py
@@ -33,7 +33,7 @@ def main():
 @click.option(
     '--html',
     is_flag=True, help='Render the results as HTML instead of a raw table.')
-def view(input_file, html):
+def show(input_file, html):
     """View a given rapport."""
     if not html:
         print_entries(input_file)

--- a/pytest_django_queries/cli_utils.py
+++ b/pytest_django_queries/cli_utils.py
@@ -1,0 +1,8 @@
+import sys
+
+import click
+
+
+def raise_error(message, exit_code=1):
+    click.echo('Error: %s' % message, file=sys.stderr)
+    sys.exit(exit_code)

--- a/pytest_django_queries/cli_utils.py
+++ b/pytest_django_queries/cli_utils.py
@@ -1,8 +1,0 @@
-import sys
-
-import click
-
-
-def raise_error(message, exit_code=1):
-    click.echo('Error: %s' % message, file=sys.stderr)
-    sys.exit(exit_code)

--- a/pytest_django_queries/tables.py
+++ b/pytest_django_queries/tables.py
@@ -1,0 +1,55 @@
+import click
+from beautifultable import BeautifulTable
+
+from pytest_django_queries.cli_utils import raise_error
+
+
+class TestEntryData(object):
+    BASE_FIELDS = [
+        ('test_name', 'Test Name')
+    ]
+    REQUIRED_FIELDS = [
+        ('query-count', 'Queries'),
+    ]
+    FIELDS = BASE_FIELDS + REQUIRED_FIELDS
+
+    def __init__(self, test_name, data):
+        """
+        :param data: The test entry's data.
+        :type data: dict
+        """
+
+        if type(data) != dict:
+            raise_error(
+                'Expected a dictionary, got %s instead' % type(data).__name__)
+
+        self._raw_data = data
+        self.test_name = test_name
+
+        for field, _ in self.REQUIRED_FIELDS:
+            setattr(self, field, self._get_required_key(field))
+
+    def _get_required_key(self, key):
+        if key in self._raw_data:
+            return self._raw_data.get(key)
+        raise_error('Got invalid data. It is missing a required key: %s' % key)
+
+
+def iter_entries(entries):
+    for module_name, module_data in entries.items():
+        yield module_name, (
+            TestEntryData(test_name, test_data)
+            for test_name, test_data in module_data.items())
+
+
+def print_entries(data):
+    table = BeautifulTable()
+    table.column_headers = ['Module', 'Tests']
+    for module_name, module_entries in iter_entries(data):
+        subtable = BeautifulTable()
+        subtable.column_headers = [field for _, field in TestEntryData.FIELDS]
+        for entry in module_entries:
+            subtable.append_row([
+                getattr(entry, field) for field, _ in TestEntryData.FIELDS])
+        table.append_row([module_name, subtable])
+    click.echo(table)

--- a/pytest_django_queries/tables.py
+++ b/pytest_django_queries/tables.py
@@ -26,29 +26,31 @@ HTML_TEMPLATE = '''
         <h1 class="text-center mt-5 mb-5">Benchmark Results</h1>
         
         {% for module_name, module_data in data %}
-            <h2 class="text-capitalize">{{ humanize(module_name) }}</h2>
-            
-            <table class="table table-bordered mb-5">
-                <thead>
-                    <tr>
-                        <th>Benchmark name</th>
-                        <th>Query count</th>
-                    </tr>
-                </thead>
+            <section>
+                <h2 class="text-capitalize">{{ humanize(module_name) }}</h2>
                 
-                <tbody>
-                    {% for test_entry in module_data %} 
+                <table class="table table-bordered mb-5">
+                    <thead>
                         <tr>
-                            <td class="text-capitalize">
-                                <code>{{ humanize(test_entry.test_name) }}</code>
-                            </td>
-                            <td>
-                                <strong>{{ test_entry['query-count'] }}</strong>
-                            </td>
+                            <th>Benchmark name</th>
+                            <th>Query count</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    
+                    <tbody>
+                        {% for test_entry in module_data %} 
+                            <tr>
+                                <td class="text-capitalize">
+                                    <code>{{ humanize(test_entry.test_name) }}</code>
+                                </td>
+                                <td>
+                                    <strong>{{ test_entry['query-count'] }}</strong>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </section>
         {% endfor %}
     </body>
 </html>

--- a/pytest_django_queries/tables.py
+++ b/pytest_django_queries/tables.py
@@ -1,7 +1,7 @@
 import click
 from beautifultable import BeautifulTable
 
-from pytest_django_queries.cli_utils import raise_error
+from pytest_django_queries.utils import raise_error, assert_type
 
 
 class TestEntryData(object):
@@ -19,9 +19,7 @@ class TestEntryData(object):
         :type data: dict
         """
 
-        if type(data) != dict:
-            raise_error(
-                'Expected a dictionary, got %s instead' % type(data).__name__)
+        assert_type(data, dict)
 
         self._raw_data = data
         self.test_name = test_name
@@ -36,10 +34,12 @@ class TestEntryData(object):
 
 
 def iter_entries(entries):
-    for module_name, module_data in entries.items():
+    for module_name, module_data in sorted(entries.items()):
+        assert_type(module_data, dict)
+
         yield module_name, (
             TestEntryData(test_name, test_data)
-            for test_name, test_data in module_data.items())
+            for test_name, test_data in sorted(module_data.items()))
 
 
 def print_entries(data):

--- a/pytest_django_queries/tables.py
+++ b/pytest_django_queries/tables.py
@@ -1,7 +1,65 @@
+from os import getenv
+
 import click
 from beautifultable import BeautifulTable
+from jinja2 import Template
 
-from pytest_django_queries.utils import raise_error, assert_type
+from pytest_django_queries.utils import assert_type, raise_error
+
+HTML_TEMPLATE = '''
+<!doctype HTML>
+<html lang="en_US">
+    <head>
+        <title>Results</title>
+        <link rel="stylesheet" 
+              href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" 
+              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+              crossorigin="anonymous" />
+        <style>
+            tbody tr > td:last-child {
+                width: 10rem
+            }
+        </style>
+    </head>
+    
+    <body class="container-fluid">
+        <h1 class="text-center mt-5 mb-5">Benchmark Results</h1>
+        
+        {% for module_name, module_data in data %}
+            <h2 class="text-capitalize">{{ humanize(module_name) }}</h2>
+            
+            <table class="table table-bordered mb-5">
+                <thead>
+                    <tr>
+                        <th>Benchmark name</th>
+                        <th>Query count</th>
+                    </tr>
+                </thead>
+                
+                <tbody>
+                    {% for test_entry in module_data %} 
+                        <tr>
+                            <td class="text-capitalize">
+                                <code>{{ humanize(test_entry.test_name) }}</code>
+                            </td>
+                            <td>
+                                <strong>{{ test_entry['query-count'] }}</strong>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endfor %}
+    </body>
+</html>
+'''
+TABLE_ATTRIBUTES = 'id="info-table" class="table table-bordered"'
+
+
+def format_underscore_name_to_human(name):
+    if name.startswith('test'):
+        _, name = name.split('test', 1)
+    return name.replace('_', ' ')
 
 
 class TestEntryData(object):
@@ -53,3 +111,10 @@ def print_entries(data):
                 getattr(entry, field) for field, _ in TestEntryData.FIELDS])
         table.append_row([module_name, subtable])
     click.echo(table)
+
+
+def print_entries_as_html(data, template):
+    template = template or Template(HTML_TEMPLATE)
+    html_content = template.render(
+        data=iter_entries(data), humanize=format_underscore_name_to_human)
+    click.echo(html_content)

--- a/pytest_django_queries/tables.py
+++ b/pytest_django_queries/tables.py
@@ -47,10 +47,18 @@ HTML_TEMPLATE = '''
                                     <strong>{{ test_entry['query-count'] }}</strong>
                                 </td>
                             </tr>
+                        {% else %}
+                            <tr>
+                                <td colspan="2">
+                                    <p>No data.</p>
+                                </td>
+                            </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </section>
+        {% else %}
+            <p>No data.</p>
         {% endfor %}
     </body>
 </html>
@@ -119,4 +127,4 @@ def print_entries_as_html(data, template):
     template = template or Template(HTML_TEMPLATE)
     html_content = template.render(
         data=iter_entries(data), humanize=format_underscore_name_to_human)
-    click.echo(html_content)
+    click.echo(html_content, nl=False)

--- a/pytest_django_queries/utils.py
+++ b/pytest_django_queries/utils.py
@@ -1,0 +1,15 @@
+import sys
+
+import click
+
+
+def raise_error(message, exit_code=1):
+    click.echo('Error: %s' % message, file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def assert_type(value, expected_type):
+    if type(value) != expected_type:
+        raise_error(
+            'Expected a %s, got %s instead' % (
+                expected_type.__name__, type(value).__name__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,28 @@
 [aliases]
 test=pytest
+
+[coverage:run]
+branch = 1
+omit =
+    */management/*
+    */migrations/*
+    */test_*.py
+    saleor/core/utils/random_data.py
+source = pytest_django_queries
+
+[coverage:report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,14 @@ from sys import version_info
 from os.path import isfile
 from setuptools import setup
 
-REQUIREMENTS = ['pytest>=4.4.0', 'freezegun']
-DEV_REQUIREMENTS = []
+REQUIREMENTS = [
+    # Plugin dependencies
+    'pytest>=4.4.0',
+
+    # Cli dependencies
+    'Click', 'beautifultable', 'json2html'
+]
+DEV_REQUIREMENTS = ['freezegun']
 
 if version_info < (3, ):
     REQUIREMENTS.append('django<2')
@@ -51,6 +57,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules'],
     install_requires=REQUIREMENTS,
-    extra_requires={
-        "dev": DEV_REQUIREMENTS},
+    extras_require={'dev': DEV_REQUIREMENTS},
     zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS = [
     # Cli dependencies
     'Click', 'beautifultable', 'jinja2'
 ]
-DEV_REQUIREMENTS = ['freezegun']
+DEV_REQUIREMENTS = ['freezegun', 'beautifulsoup4', 'lxml']
 
 if version_info < (3, ):
     REQUIREMENTS.append('django<2')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'pytest>=4.4.0',
 
     # Cli dependencies
-    'Click', 'beautifultable', 'json2html'
+    'Click', 'beautifultable', 'jinja2'
 ]
 DEV_REQUIREMENTS = ['freezegun']
 
@@ -39,7 +39,8 @@ setup(
     packages=['pytest_django_queries'],
     include_package_data=True,
     entry_points={
-        'pytest11': ['django_queries = pytest_django_queries.plugin']},
+        'pytest11': ['django_queries = pytest_django_queries.plugin'],
+        'console_scripts': ['django-queries = pytest_django_queries.cli:main']},
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 from textwrap import dedent
 
 import pytest
+from bs4 import BeautifulSoup
 from click.testing import CliRunner
 
 from pytest_django_queries import cli
@@ -11,7 +12,7 @@ def test_load_invalid_json_file_triggers_error(testdir):
     testdir.makefile('.json', test_file='')
     runner = CliRunner()
     result = runner.invoke(cli.main, ['show', 'test_file.json'])
-    assert result.exit_code == 2
+    assert result.exit_code == 2, result.stdout
     assert (
         'Error: Invalid value for "INPUT_FILE": '
         'The file is not valid json: ') in result.stdout
@@ -21,7 +22,7 @@ def test_load_invalid_base_type_json_file_triggers_error(testdir):
     testdir.makefile('.json', test_file='[]')
     runner = CliRunner()
     result = runner.invoke(cli.main, ['show', 'test_file.json'])
-    assert result.exit_code == 2
+    assert result.exit_code == 2, result.stdout
     assert (
         'The file is not a dictionary') in result.stdout
 
@@ -35,16 +36,25 @@ def test_load_invalid_test_entry_value_type_json_file_triggers_error(
     testdir.makefile('.json', test_file=test_data)
     runner = CliRunner()
     result = runner.invoke(cli.main, ['show', 'test_file.json'])
-    assert result.exit_code == 1
+    assert result.exit_code == 1, result.stdout
     assert (
         'Error: Expected a dict, got int instead\n') in result.stdout
+
+
+def test_load_invalid_test_entry_missing_value_triggers_error(testdir):
+    testdir.makefile('.json', test_file='{"test": {"something": {}}}')
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['show', 'test_file.json'])
+    assert result.exit_code == 1, result.stdout
+    assert (
+        'Got invalid data. It is missing a required key: query-count') in result.stdout
 
 
 def test_load_valid_empty_json_file_is_success(testdir):
     testdir.makefile('.json', test_file='{}')
     runner = CliRunner()
     result = runner.invoke(cli.main, ['show', 'test_file.json'])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout
     assert result.stdout.strip() == ''
 
 
@@ -92,3 +102,28 @@ def test_load_valid_json_file_shows_correct_data(testdir):
         | module3 |                         |
         +---------+-------------------------+
     """).strip()
+
+
+def test_load_valid_json_file_shows_correct_html_data(testdir):
+    testdir.makefile('.json', test_file=json.dumps(VALID_DATA))
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['html', 'test_file.json'])
+    assert result.exit_code == 0, result.stdout
+    soup = BeautifulSoup(result.stdout, 'lxml')
+    sections = soup.select('section')
+    assert len(sections) == len(VALID_DATA)
+
+    for html_section, expected_data in zip(sections, sorted(VALID_DATA.items())):
+        expected_title, expected_data = \
+            expected_data[0], sorted(expected_data[1].items())
+        assert html_section.select_one('h2').get_text(strip=True) == expected_title
+        for html_row, test_data in zip(
+                html_section.select('tbody > tr'), expected_data):
+            expected_test_name, expected_data = \
+                test_data[0].split('test')[1], test_data[1]
+            received_test_name, received_count = \
+                html_row.select('td')
+            assert received_test_name.get_text(strip=True) == expected_test_name
+            assert (
+                received_count.get_text(strip=True) == str(expected_data['query-count'])
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+from click.testing import CliRunner
+
+from pytest_django_queries import cli
+
+
+def test_load_invalid_json_file_triggers_error(testdir):
+    testdir.makefile('.json', test_file='')
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    assert result.exit_code == 2
+    assert (
+        'Error: Invalid value for "INPUT_FILE": '
+        'The file is not valid json: '
+        'Expecting value: line 1 column 1 (char 0)\n') in result.stdout
+
+
+def test_load_valid_json_file_is_success(testdir):
+    testdir.makefile('.json', test_file='{}')
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from pytest_django_queries import cli
 def test_load_invalid_json_file_triggers_error(testdir):
     testdir.makefile('.json', test_file='')
     runner = CliRunner()
-    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 2
     assert (
         'Error: Invalid value for "INPUT_FILE": '
@@ -18,7 +18,7 @@ def test_load_invalid_json_file_triggers_error(testdir):
 def test_load_invalid_base_type_json_file_triggers_error(testdir):
     testdir.makefile('.json', test_file='[]')
     runner = CliRunner()
-    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 2
     assert (
         'The file is not a dictionary') in result.stdout
@@ -27,7 +27,7 @@ def test_load_invalid_base_type_json_file_triggers_error(testdir):
 def test_load_invalid_test_entry_value_type_json_file_triggers_error(testdir):
     testdir.makefile('.json', test_file='{"test": 123}')
     runner = CliRunner()
-    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 1
     assert (
         'Error: Expected a dictionary, got int instead\n') in result.stdout
@@ -36,7 +36,7 @@ def test_load_invalid_test_entry_value_type_json_file_triggers_error(testdir):
 def test_load_valid_empty_json_file_is_success(testdir):
     testdir.makefile('.json', test_file='{}')
     runner = CliRunner()
-    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 0
     assert result.stdout.strip() == ''
 
@@ -62,6 +62,6 @@ VALID_DATA = {
 def test_load_valid_json_file_shows_correct_data(testdir):
     testdir.makefile('.json', test_file=json.dumps(VALID_DATA))
     runner = CliRunner()
-    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 0, result.stdout
     assert result.stdout.strip() == ''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import json
+from textwrap import dedent
 
+import pytest
 from click.testing import CliRunner
 
 from pytest_django_queries import cli
@@ -24,13 +26,18 @@ def test_load_invalid_base_type_json_file_triggers_error(testdir):
         'The file is not a dictionary') in result.stdout
 
 
-def test_load_invalid_test_entry_value_type_json_file_triggers_error(testdir):
-    testdir.makefile('.json', test_file='{"test": 123}')
+@pytest.mark.parametrize('test_data', (
+    '{"test": 123}',
+    '{"test": {"something": 123}}'))
+def test_load_invalid_test_entry_value_type_json_file_triggers_error(
+        testdir, test_data):
+
+    testdir.makefile('.json', test_file=test_data)
     runner = CliRunner()
     result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 1
     assert (
-        'Error: Expected a dictionary, got int instead\n') in result.stdout
+        'Error: Expected a dict, got int instead\n') in result.stdout
 
 
 def test_load_valid_empty_json_file_is_success(testdir):
@@ -44,15 +51,15 @@ def test_load_valid_empty_json_file_is_success(testdir):
 VALID_DATA = {
     'module1': {
         'test1': {
-            'query_count': 0
+            'query-count': 0
         },
         'test2': {
-            'query_count': 1
+            'query-count': 1
         }
     },
     'module2': {
         'test1': {
-            'query_count': 123
+            'query-count': 123
         }
     },
     'module3': {}
@@ -64,4 +71,24 @@ def test_load_valid_json_file_shows_correct_data(testdir):
     runner = CliRunner()
     result = runner.invoke(cli.main, ['show', 'test_file.json'])
     assert result.exit_code == 0, result.stdout
-    assert result.stdout.strip() == ''
+    assert result.stdout.strip() == dedent("""
+        +---------+-------------------------+
+        | Module  |          Tests          |
+        +---------+-------------------------+
+        | module1 | +-----------+---------+ |
+        |         | | Test Name | Queries | |
+        |         | +-----------+---------+ |
+        |         | |   test1   |    0    | |
+        |         | +-----------+---------+ |
+        |         | |   test2   |    1    | |
+        |         | +-----------+---------+ |
+        +---------+-------------------------+
+        | module2 | +-----------+---------+ |
+        |         | | Test Name | Queries | |
+        |         | +-----------+---------+ |
+        |         | |   test1   |   123   | |
+        |         | +-----------+---------+ |
+        +---------+-------------------------+
+        | module3 |                         |
+        +---------+-------------------------+
+    """).strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from click.testing import CliRunner
 
 from pytest_django_queries import cli
@@ -10,13 +12,56 @@ def test_load_invalid_json_file_triggers_error(testdir):
     assert result.exit_code == 2
     assert (
         'Error: Invalid value for "INPUT_FILE": '
-        'The file is not valid json: '
-        'Expecting value: line 1 column 1 (char 0)\n') in result.stdout
+        'The file is not valid json: ') in result.stdout
 
 
-def test_load_valid_json_file_is_success(testdir):
+def test_load_invalid_base_type_json_file_triggers_error(testdir):
+    testdir.makefile('.json', test_file='[]')
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    assert result.exit_code == 2
+    assert (
+        'The file is not a dictionary') in result.stdout
+
+
+def test_load_invalid_test_entry_value_type_json_file_triggers_error(testdir):
+    testdir.makefile('.json', test_file='{"test": 123}')
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    assert result.exit_code == 1
+    assert (
+        'Error: Expected a dictionary, got int instead\n') in result.stdout
+
+
+def test_load_valid_empty_json_file_is_success(testdir):
     testdir.makefile('.json', test_file='{}')
     runner = CliRunner()
     result = runner.invoke(cli.main, ['view', 'test_file.json'])
     assert result.exit_code == 0
+    assert result.stdout.strip() == ''
+
+
+VALID_DATA = {
+    'module1': {
+        'test1': {
+            'query_count': 0
+        },
+        'test2': {
+            'query_count': 1
+        }
+    },
+    'module2': {
+        'test1': {
+            'query_count': 123
+        }
+    },
+    'module3': {}
+}
+
+
+def test_load_valid_json_file_shows_correct_data(testdir):
+    testdir.makefile('.json', test_file=json.dumps(VALID_DATA))
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ['view', 'test_file.json'])
+    assert result.exit_code == 0, result.stdout
     assert result.stdout.strip() == ''


### PR DESCRIPTION
This PR adds a CLI interface to the package. It adds a `show` command that takes a file.

- By default it prints to stdout the file content formatted as a table;
- By passing `--html` it will output a generated html code to stdout.

Todo:
- [x] Implement raw visualization;
- [x] Implement HTML visualization;
  - [x] Add test for rendering;
  - [x] Add test for rendering no data;
  - [x] Add test for rendering with a custom template both:
    - [x] Valid
    - [x] Invalid
- [x] Add test for missing required key;
- [ ] Update README:
  - [ ] Add `--help`
  - [x] Add the `show` command
  - [x] Add the `html` command
    - [ ] Add how to customize it.
