### PR TITLE
Fix wrong coverage report by dropping pytest-cov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ venv/
 *.pyc
 *.egg-info/
 .pytest*
-
+.coverage
+*cov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ python:
   - "3.4"
   - "3.5"
 
+cache:
+  pip: true
+  directories:
+    - node_modules
+    - $HOME/.cache/pip
+
 env:
   - DJANGO="==1.11.*"
   - DJANGO="==2.1.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,40 +15,34 @@ env:
   - DJANGO="==2.2.*"
   - DJANGO="master"
 
-jobs:
+matrix:
+  fast_finish: true
   include:
-    - stage: Python 3.5 - Django 2.2
-      dist: xenial
+    - dist: xenial
       python: "3.5"
       env:
         - DJANGO="==2.2.*"
 
-    - stage: Python 3.6 - Django 2.2
-      dist: xenial
+    - dist: xenial
       python: "3.6"
       env:
         - DJANGO="==2.2.*"
 
-    - stage: Python 3.6 - Django Master
-      dist: xenial
+    - dist: xenial
       python: "3.6"
       env:
         - DJANGO="master"
 
-    - stage: Python 3.7 - Django 2.2
-      dist: xenial
+    - dist: xenial
       python: "3.7"
       env:
         - DJANGO="==2.2.*"
 
-    - stage: Python 3.7 - Django Master
-      dist: xenial
+    - dist: xenial
       python: "3.7"
       env:
         - DJANGO="master"
 
-matrix:
-  fast_finish: true
   exclude:
     - python: "2.7"
       env: DJANGO="==2.1.*"
@@ -76,15 +70,11 @@ install:
     [ "$DJANGO" == master ] \
        && django=https://github.com/django/django/archive/master.tar.gz \
        || django="django${DJANGO}"
-  - pip install tox-travis codecov pytest-cov $django
+  - pip install tox-travis codecov coverage $django
   - ./setup.py develop
+  - pip install -e .[dev]
 
 script:
-  - >
-    if [ $TRAVIS_PYTHON_VERSION == '2.7' ]; then
-      pytest
-    else
-      pytest --cov --cov-report=
-    fi
+  - coverage run --source pytest_django_queries -m pytest
 
 after_success: codecov

--- a/README.md
+++ b/README.md
@@ -59,3 +59,10 @@ environment variable to any given valid path.
 ## Visualising Results
 
 ## Comparing results
+
+## Development
+Install the development requirements by running the below command.
+
+```shell
+pip install -e .[dev]
+```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ environment variable to any given valid path.
 ## Comparing results
 
 ## Development
-Install the development requirements by running the below command.
+First of all, clone the project locally. Then, install it using the below command.
+
+```shell
+./setup.py develop
+```
+
+After that, you need to install the development requirements. For that, 
+run the below command.
 
 ```shell
 pip install -e .[dev]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os.path import isfile
 from setuptools import setup
 
 REQUIREMENTS = ['pytest', 'django', 'freezegun']
-TEST_REQUIREMENTS = []
+DEV_REQUIREMENTS = []
 
 
 if isfile('README.md'):
@@ -45,5 +45,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules'],
     install_requires=REQUIREMENTS,
-    tests_require=TEST_REQUIREMENTS,
+    extra_requires={
+        "dev": DEV_REQUIREMENTS},
     zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
+from sys import version_info
 from os.path import isfile
 from setuptools import setup
 
-REQUIREMENTS = ['pytest', 'django', 'freezegun']
+REQUIREMENTS = ['pytest>=4.4.0', 'freezegun']
 DEV_REQUIREMENTS = []
+
+if version_info < (3, ):
+    REQUIREMENTS.append('django<2')
+else:
+    REQUIREMENTS.append('django')
 
 
 if isfile('README.md'):


### PR DESCRIPTION
## Removing pytest-cov for coverage.py
After some research I figured out two things about the coverage being wrongly reported over `plugin.py`:
1. `pytest-cov` is starting to catch reporting only once pytest is ready. Thus, when `pytest` discovers and loads `plugin.py`, the file is imported and never properly marked as covered (imported) by `pytest-cov`.
1. `pytest-cov` is not the best solution to report the coverage. `coverage.py` works even better with pytest and is already reporting before pytest is running/ready, thus we get the correct `plugin.py` coverage.

## Stopping using `test_requires`
The setup manifest is quite annoying when it comes to the tests requirements. The tests requirements provided to `test_requires` can only be installed when running `./setup.py test`, so we are obligated to run `./setup.py test` and no other command for the first run. Which is really annoying depending on the use case (despite the fact that we can run any test-runner using `./setup.py test`).

It's just better to be able to explicitly say that we want to install the test/dev requirements and then do whatever we want with them... including running tests... or not.

Thus, we will just use `extra_requires` with the `dev` flag and run `pip -e .[dev]`. That's much better.

## Remove stages on travis
What's great about stages on travis, is that we get nice looking names... that's it. But that's not what stages are meant to be. So instead, let's just use `matrix: include: ...` which is more compact and quicker to run.

At the same time, I decided to put django `master` to the tests allowed to fail as we never know... things can break. Hopefully master will always build... but not forever.

## Forcing `pytest > 4.4.0`
Pytest 4 is compatible with python 2.7 and 3.4, so we can without issue enforce it. The issue with pytest 3 is that `request.node.get_closest_marker` does not exist yet, instead we would have used `request.node.get_marker`. But it's fine as we don't have to maintain back compatibility with the old pytest version.

So instead, we want to make sure that nobody or pip tried to use pytest 3 or a too old version that may or won't work with the plugin.