### PR TITLE
Changed the report save path to be always the same one & drop env for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.0.dev2 - May 13th 2019
+- [x] In #12, stopped storing the benchmark results in a file named after the current date and time.
+      Instead, it will always save into `.django-queries` and won't contain a `json` file extension
+      anymore to make it less appealing as it's not meant to be read by a human.
+- [x] In #12, dropped the environment variable `PYTEST_QUERIES_SAVE_PATH` and replaced
+      and introduced the `--django-db-bench PATH` option instead, which does exactly the same thing.
+
 ## v1.0.0.dev1 - May 12th 2019
 - [x] Introduced the cli (#3) with two commands:
   - [x] `show` that process a given benchmark result to render a summary table

--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ compose its data, see [Visualising Results](#visualising-results) for more detai
 ## Testing locally
 Simply install `pytest-django-queries` through pip and run your 
 tests using `pytest`. A report should have been generated in your
-current working directory in a JSON file prefixed with `.pytest-queries`.
+current working directory in a file called with `.pytest-queries`.
 
-Note: to override the save path, set the `PYTEST_QUERIES_SAVE_PATH`
-environment variable to any given valid path.
+Note: to override the save path, pass the `--django-db-bench PATH` option to pytest.
 
 ## Visualising Results
 You can generate a table from the tests results by using the `show` command:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS = [
     # Cli dependencies
     'Click', 'beautifultable', 'jinja2'
 ]
-DEV_REQUIREMENTS = ['freezegun', 'beautifulsoup4', 'lxml']
+DEV_REQUIREMENTS = ['beautifulsoup4', 'lxml']
 
 if version_info < (3, ):
     REQUIREMENTS.append('django<2')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,1 @@
-import pytest
-
-from pytest_django_queries.plugin import ENV_QUERY_SAVE_PATH
-
 pytest_plugins = 'pytester'
-
-
-@pytest.fixture()
-def temp_results(testdir, monkeypatch):
-    # Make a dummy path where to save the results
-    # and override the dump path by setting the PYTEST_QUERIES_SAVE_PATH
-    # environment variable
-    results_path = testdir.tmpdir.join('results.json')
-    monkeypatch.setenv(ENV_QUERY_SAVE_PATH, str(results_path))
-
-    return testdir, results_path

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -100,3 +100,14 @@ def test_marker_message(testdir):
     result.stdout.fnmatch_lines([
         '@pytest.mark.count_queries: '
         'Mark the test as to have their queries counted.'])
+
+
+def test_implements_custom_options(testdir):
+    """Ensure the custom options are added to pytest."""
+    result = testdir.runpytest('--help')
+    result.stdout.fnmatch_lines([
+        'django-queries:',
+        '*--django-db-bench=PATH',
+        '*Output file for storing the results. Default: .pytest-',
+        '*queries'
+    ])


### PR DESCRIPTION
<!-- Please reference all the relevant issues -->
Closes #12.

- [x] In #12, stopped storing the benchmark results in a file named after the current date and time.
      Instead, it will always save into `.django-queries` and won't contain a `json` file extension
      anymore to make it less appealing as it's not meant to be read by a human.
- [x] In #12, dropped the environment variable `PYTEST_QUERIES_SAVE_PATH` and replaced
      and introduced the `--django-db-bench PATH` option instead, which does exactly the same thing.

## Changes Checklist
<!-- Please keep this section and check what's true -->
- [x] The changes were tested (manually)
- [x] The changes are tested automatically (pytest)
- [x] The changes are optimized and clean
- [x] The changes are documented:
  - [x] The code is documented
  - [x] The readme is up to date
  - [ ] The documentation (readthedocs) is up to date and tested
