### PR TITLE
Second release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ It will generate something [like this](https://pytest-django-queries.readthedocs
 
 ## Comparing Results
 
-When running pytest, pass the `--django-backup-queries` (can take a path, optionally)
-then you can run `django-queries diff` to generate results looking like this:
+You can run `django-queries backup` (can take a path, optionally) after
+running your tests then rerun them. After that, you can run `django-queries diff`
+to generate results looking like this:
 
 <a href='./docs/_static/diff_results.png'>
   <img src='./docs/_static/diff_results.png' alt='screenshot' width='500px' />

--- a/README.md
+++ b/README.md
@@ -59,11 +59,50 @@ You will find the [full documentation here](https://pytest-django-queries.readth
 
 <!-- TODO: insert a graphic here to explain how it works -->
 
+## Recommendation when Using Fixtures
+You might end up in the case where you want to add fixtures that are generating queries
+that you don't want to be counted in the results–or simply, you want to use the
+`pytest-django` plugin alongside of `pytest-django-queries`, which will generate
+unwanted queries in your results.
+
+For that, you will want to put the `count_queries` fixture as the last fixture to execute.
+
+But at the same time, you might want to use the the power of pytest markers, to separate
+the queries counting tests from other tests. In that case, you might want to do something
+like this to tell the marker to not automatically inject the `count_queries` fixture into
+your test:
+
+```python
+import pytest
+
+
+@pytest.mark.count_queries(autouse=False)
+def test_retrieve_main_menu(fixture_making_queries, count_queries):
+    pass
+```
+
+Notice the usage of the keyword argument `autouse=False` and the `count_queries` fixture
+being placed last.
+
+## Using pytest-django alongside of pytest-django-queries
+We recommend you to do the following when using `pytest-django`:
+
+```python
+import pytest
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_retrieve_main_menu(any_fixture, other_fixture, count_queries):
+    pass
+```
+
+
 ## Integrating with GitHub
 
 TBA.
 
-## Testing locally
+## Testing Locally
 Simply install `pytest-django-queries` through pip and run your
 tests using `pytest`. A report should have been generated in your
 current working directory in a file called with `.pytest-queries`.
@@ -99,7 +138,7 @@ You will get something like this to represent the results:
 +---------+-------------------------+
 ```
 
-## Exporting the results (HTML)
+## Exporting the Results (HTML)
 For a nicer presentation, use the `html` command, to export the results as HTML.
 ```shell
 django-queries html
@@ -107,7 +146,7 @@ django-queries html
 
 It will generate something [like this](https://pytest-django-queries.readthedocs.io/en/latest/html_export_results.html).
 
-## Comparing results
+## Comparing Results
 
 When running pytest, pass the `--django-backup-queries` (can take a path, optionally)
 then you can run `django-queries diff` to generate results looking like this:

--- a/docs/diff.rst
+++ b/docs/diff.rst
@@ -3,10 +3,10 @@
 The Diff Command
 ----------------
 
-The plugin can backup the test results for you if you pass the ``--django-backup-queries [BACKUP_PATH]`` parameter to it. It will create a backup to ``.pytest-query.old`` by default if previous results were found.
+The plugin can backup the test results for you if you run the ``django-queries backup [BACKUP_PATH]`` command. It will create a backup to ``.pytest-query.old`` by default if previous results were found.
 
 .. warning::
 
     Bear in mind that it will override any existing backup file in the provided or default path.
 
-After running ``pytest --django-backup-queries``, you can run ``django-queries diff`` to show the changes. Make sure you actually had previous results, otherwise it will have nothing to compare.
+After running ``pytest`` again, you can run ``django-queries diff`` to show the changes. Make sure you actually had previous results, otherwise it will have nothing to compare.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,6 +67,11 @@ Quick Start
         :align: center
 
 
+.. warning::
+
+    Please take a quick look at our :ref:`recommendations <recommendations>` before starting using the plugin in your project tests.
+
+
 Getting Help
 ============
 Feel free to `open an issue <https://github.com/NyanKiyoshi/pytest-django-queries/issues>`_ in our GitHub repository! Or reach `hello@vanille.bid <mailto:hello@vanille.bid>`_.
@@ -83,6 +88,7 @@ More Topics
 .. toctree::
     :maxdepth: 2
 
+    recommendations
     diff
     customize
     usage

--- a/docs/recommendations.rst
+++ b/docs/recommendations.rst
@@ -1,0 +1,40 @@
+.. _recommendations:
+
+Recommendations (Must Read!)
+----------------------------
+
+Fixtures That Generate Queries
+++++++++++++++++++++++++++++++
+
+If your test case is using fixtures that are generating any database queries, you will end up with unwanted queries being counted in your tests. For that reason, we recommend you to manually request the usage of the ``count_queries`` fixture and put it as the last parameter of your test.
+
+By doing so, you will be sure that the query counter is actually always executed last and does not wrap any other fixtures.
+
+Along side, you might want to still use the plugin's ``count_queries`` marker which is useful to keep your tests separated from the query counting tests.
+
+Your code will look like something like this:
+
+.. code-block:: python
+
+    import pytest
+
+
+    @pytest.mark.count_queries(autouse=False)
+    def test_retrieve_main_menu(fixture_making_queries, count_queries):
+        pass
+
+
+Using ``pytest-django`` Alongside of Counting Queries
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+You are most likely using the ``pytest-django`` plugin which is really useful for django testing. By following the previous section's example, you might want to unblock the test database as well. You would do something like this:
+
+.. code-block:: python
+
+    import pytest
+
+
+    @pytest.mark.django_db
+    @pytest.mark.count_queries(autouse=False)
+    def test_retrieve_main_menu(any_fixture, other_fixture, count_queries):
+        pass

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,6 +25,12 @@ Or pass a custom path.
       Whether the old results should be backed up or not before overriding.
 
 
+Running Tests Separately
+++++++++++++++++++++++++
+
+To only run the ``count_queries`` marked tests and nothing else, you can run ``pytest -v -m count_queries``.
+
+
 CLI Usage
 =========
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,9 @@ Customizing the Save Path
 Backing Up Results
 ++++++++++++++++++
 
-You can pass the ``--django-backup-queries`` parameter to backup previous results to `.pytest-django.old``.
+The easiest way is to run the ``django-queries backup`` command which will create a copy of the current results.
+
+Another way is by passing the ``--django-backup-queries`` parameter to backup previous results to `.pytest-django.old``.
 
 Or pass a custom path.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,7 +22,7 @@ Or pass a custom path.
 .. code-block:: text
 
     --django-backup-queries=[PATH]
-    Whether the old results should be backed up or not before overriding.
+      Whether the old results should be backed up or not before overriding.
 
 
 CLI Usage
@@ -52,11 +52,13 @@ The HTML Command
     Render the results as HTML instead of a raw table.
 
     Options:
-        -o                  The path to save the HTML file into
-                            django-queries.html by default.
-                            You can pass a dash (-) to write to stdout as well.
-        --template INTEGER
-        --help              Show this message and exit.
+        -o                      The path to save the HTML file into
+                                django-queries.html by default.
+                                You can pass a dash (-) to write to stdout as well.
+
+        --template JINJA2_FILE  Use a custom jinja2 template for rendering HTML results.
+
+        --help                  Show this message and exit.
 
 
 The SHOW Command

--- a/pytest_django_queries/cli.py
+++ b/pytest_django_queries/cli.py
@@ -27,11 +27,11 @@ def _write_html_to_file(content, path):
         fp.write(content)
 
 
-class JsonFileParamType(click.File):
-    name = "integer"
+class JsonReportFileParamType(click.File):
+    name = "report_file"
 
     def convert(self, value, param, ctx):
-        fp = super(JsonFileParamType, self).convert(value, param, ctx)
+        fp = super(JsonReportFileParamType, self).convert(value, param, ctx)
         try:
             loaded = json.load(fp)
             if type(loaded) is not dict:
@@ -42,7 +42,7 @@ class JsonFileParamType(click.File):
 
 
 class Jinja2TemplateFile(click.File):
-    name = "integer"
+    name = "jinja2_file"
 
     def convert(self, value, param, ctx):
         fp = super(Jinja2TemplateFile, self).convert(value, param, ctx)
@@ -61,7 +61,7 @@ def main():
 
 @main.command()
 @click.argument(
-    "input_file", type=JsonFileParamType("r"), default=DEFAULT_RESULT_FILENAME
+    "input_file", type=JsonReportFileParamType("r"), default=DEFAULT_RESULT_FILENAME
 )
 def show(input_file):
     """View a given rapport."""
@@ -70,10 +70,22 @@ def show(input_file):
 
 @main.command()
 @click.argument(
-    "input_file", type=JsonFileParamType("r"), default=DEFAULT_RESULT_FILENAME
+    "input_file", type=JsonReportFileParamType("r"), default=DEFAULT_RESULT_FILENAME
 )
-@click.option("-o", "--output", type=str, default=DEFAULT_HTML_SAVE_PATH)
-@click.option("--template", type=Jinja2TemplateFile("r"), default=DEFAULT_TEMPLATE_PATH)
+@click.option(
+    "-o",
+    "--output",
+    type=str,
+    default=DEFAULT_HTML_SAVE_PATH,
+    help="The path to save the HTML file into django-queries.html by default."
+    "You can pass a dash (-) to write to stdout as well.",
+)
+@click.option(
+    "--template",
+    type=Jinja2TemplateFile("r"),
+    default=DEFAULT_TEMPLATE_PATH,
+    help="Use a custom jinja2 template for rendering HTML results.",
+)
 def html(input_file, output, template):
     """
     Render the results as HTML instead of a raw table.
@@ -90,10 +102,10 @@ def html(input_file, output, template):
 
 @main.command()
 @click.argument(
-    "left_file", type=JsonFileParamType("r"), default=DEFAULT_OLD_RESULT_FILENAME
+    "left_file", type=JsonReportFileParamType("r"), default=DEFAULT_OLD_RESULT_FILENAME
 )
 @click.argument(
-    "right_file", type=JsonFileParamType("r"), default=DEFAULT_RESULT_FILENAME
+    "right_file", type=JsonReportFileParamType("r"), default=DEFAULT_RESULT_FILENAME
 )
 def diff(left_file, right_file):
     """Render the diff as a console table with colors."""

--- a/pytest_django_queries/cli.py
+++ b/pytest_django_queries/cli.py
@@ -13,6 +13,7 @@ from pytest_django_queries.plugin import (
     DEFAULT_RESULT_FILENAME,
 )
 from pytest_django_queries.tables import entries_to_html, print_entries
+from pytest_django_queries.utils import create_backup
 
 HERE = dirname(__file__)
 DEFAULT_TEMPLATE_PATH = abspath(pathjoin(HERE, "templates", "default_bootstrap.jinja2"))
@@ -122,6 +123,14 @@ def diff(left_file, right_file):
         for line in lines:
             fg_color = DIFF_TERM_COLOR.get(line[0], DEFAULT_TERM_DIFF_COLOR)
             click.secho(line, fg=fg_color)
+
+
+@main.command()
+@click.argument("target_path", type=str, default=DEFAULT_OLD_RESULT_FILENAME)
+def backup(target_path):
+    source_path = DEFAULT_RESULT_FILENAME
+    click.echo("{0} -> {1}".format(source_path, target_path))
+    create_backup(source_path, target_path)
 
 
 if __name__ == "__main__":

--- a/pytest_django_queries/filters.py
+++ b/pytest_django_queries/filters.py
@@ -1,4 +1,7 @@
+import re
+
+BLACKLISTED_WORDS_RE = re.compile(r"(^|\.)tests?\.?", re.I)
+
+
 def format_underscore_name_to_human(name):
-    if name.startswith("test"):
-        _, name = name.split("test", 1)
-    return name.replace("_", " ").strip()
+    return re.sub(BLACKLISTED_WORDS_RE, "", name.replace("_", " ")).strip()

--- a/pytest_django_queries/plugin.py
+++ b/pytest_django_queries/plugin.py
@@ -1,11 +1,12 @@
 import json
-import shutil
 from os.path import isfile
 
 import pytest
 from django.test.utils import CaptureQueriesContext
 
 # Defines the plugin marker name
+from pytest_django_queries.utils import create_backup
+
 PYTEST_QUERY_COUNT_MARKER = "count_queries"
 PYTEST_QUERY_COUNT_FIXTURE_NAME = "count_queries"
 DEFAULT_RESULT_FILENAME = ".pytest-queries"
@@ -18,10 +19,6 @@ def _set_session(config, new_session):
 
 def _get_session(request):
     return request.config.pytest_django_queries_session
-
-
-def _create_backup(save_path, backup_path):
-    shutil.copy(save_path, backup_path)
 
 
 class _Session(object):
@@ -43,7 +40,7 @@ class _Session(object):
 
     def save_json(self):
         if self.backup_path and isfile(self.save_path):
-            _create_backup(self.save_path, self.backup_path)
+            create_backup(self.save_path, self.backup_path)
 
         with open(self.save_path, "w") as fp:
             json.dump(self._data, fp, indent=2)

--- a/pytest_django_queries/plugin.py
+++ b/pytest_django_queries/plugin.py
@@ -78,16 +78,6 @@ def pytest_addoption(parser):
 
 
 @pytest.mark.tryfirst
-def pytest_configure(config):
-    """Append the plugin markers to the pytest configuration."""
-    config_line = (
-        "%s: Mark the test as to have their queries counted."
-        "" % PYTEST_QUERY_COUNT_MARKER
-    )
-    config.addinivalue_line("markers", config_line)
-
-
-@pytest.mark.tryfirst
 def pytest_load_initial_conftests(early_config, parser, args):
     """
     :param early_config:
@@ -96,6 +86,12 @@ def pytest_load_initial_conftests(early_config, parser, args):
     :type args: tuple|list
     :return:
     """
+    early_config.addinivalue_line(
+        "markers",
+        "%s: Mark the test as to have their database query counted."
+        "" % PYTEST_QUERY_COUNT_MARKER,
+    )
+
     save_path = early_config.known_args_namespace.queries_results_save_path
     backup_path = early_config.known_args_namespace.queries_backup_results
 

--- a/pytest_django_queries/utils.py
+++ b/pytest_django_queries/utils.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 
 import click
@@ -14,3 +15,7 @@ def assert_type(value, expected_type):
             "Expected a %s, got %s instead"
             % (expected_type.__name__, type(value).__name__)
         )
+
+
+def create_backup(save_path, backup_path):
+    shutil.copy(save_path, backup_path)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author="NyanKiyoshi",
     author_email="hello@vanille.bid",
     url="https://github.com/NyanKiyoshi/pytest-django-queries/",
-    description="Generate performance rapports from your django database "
+    description="Generate performance reports from your django database "
     "performance tests.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -219,3 +219,21 @@ def test_export_to_html_using_invalid_custom_template_should_fail(testdir):
         'Error: Invalid value for "--template": '
         "The file is not a valid jinja2 template: tag name expected" in result.stdout
     )
+
+
+def test_backup_command_is_making_a_backup(testdir):
+    results_file = str(testdir.tmpdir.join(".pytest-queries"))
+
+    with open(results_file, "w") as fp:
+        fp.write("hello!")
+
+    backup_file = testdir.tmpdir.join("backup.json")
+
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["backup", "backup.json"])
+    assert result.exit_code == 0, result.stdout
+    assert result.stdout == ".pytest-queries -> backup.json\n"
+
+    assert backup_file.check()
+    with open(str(backup_file), "r") as fp:
+        assert fp.read() == "hello!"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pytest_django_queries import filters
+
+
+@pytest.mark.parametrize(
+    "input_, output",
+    [
+        ("tests.api.test_something", "api something"),
+        ("test_something_test", "something test"),
+    ],
+)
+def test_humanize(input_, output):
+    assert filters.format_underscore_name_to_human(input_) == output

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -82,7 +82,7 @@ def test_plugin_exports_results_even_when_test_fails(testdir):
     )
     results = testdir.runpytest("--django-db-bench", results_path)
 
-    # Ensure the tests have passed
+    # Ensure the tests have failed
     results.assert_outcomes(0, 0, 1)
 
     # Ensure the results file was created
@@ -92,6 +92,65 @@ def test_plugin_exports_results_even_when_test_fails(testdir):
             "test_failure": {"query-count": 0}
         }
     }
+
+
+def test_plugin_marker_without_autouse_handles_other_fixtures(testdir):
+    """Ensure marking a test for counting queries is not counting other fixtures."""
+
+    results_path = testdir.tmpdir.join("results.json")
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture()
+        def fixture_with_db_queries():
+            from django.db import connection
+
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT date('now');")
+                cursor.execute("SELECT 1;")
+                cursor.fetchone()
+
+        @pytest.mark.count_queries(autouse=False)
+        def test_with_side_effects(fixture_with_db_queries, count_queries):
+            pass
+    """
+    )
+    results = testdir.runpytest("--django-db-bench", results_path)
+
+    # Ensure the tests have passed
+    results.assert_outcomes(1, 0, 0)
+
+    # Ensure the results file was created
+    assert results_path.check()
+    assert json.load(results_path) == {
+        "test_plugin_marker_without_autouse_handles_other_fixtures": {
+            "test_with_side_effects": {"query-count": 0}
+        }
+    }
+
+
+def test_plugin_marker_without_autouse_disabled(testdir):
+    """Ensure marking a test for counting queries without autouse
+    is actually not counting queries unless the fixture is used manually."""
+
+    results_path = testdir.tmpdir.join("results.json")
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.count_queries(autouse=False)
+        def test_without_autouse():
+            pass
+    """
+    )
+    results = testdir.runpytest("--django-db-bench", results_path)
+
+    # Ensure the tests have passed
+    results.assert_outcomes(1, 0, 0)
+
+    # Ensure not results were found
+    assert not results_path.check()
 
 
 def test_fixture_is_backing_up_old_results(testdir):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -210,7 +210,7 @@ def test_fixture_is_not_backing_up_if_not_asked_to(testdir):
     # and triggers a counting of the query number
     testdir.makepyfile(test_file=DUMMY_TEST_QUERY)
 
-    with mock.patch("pytest_django_queries.plugin._create_backup") as mocked_backup:
+    with mock.patch("pytest_django_queries.plugin.create_backup") as mocked_backup:
         results = testdir.runpytest("--django-db-bench", results_path)
         assert mocked_backup.call_count == 0
 
@@ -228,7 +228,7 @@ def test_fixture_is_backing_up_old_results_to_default_path_if_no_path_provided(t
     # and triggers a counting of the query number
     testdir.makepyfile(test_file=DUMMY_TEST_QUERY)
 
-    with mock.patch("pytest_django_queries.plugin._create_backup") as mocked_backup:
+    with mock.patch("pytest_django_queries.plugin.create_backup") as mocked_backup:
         from pytest_django_queries.plugin import DEFAULT_OLD_RESULT_FILENAME
 
         results = testdir.runpytest(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -188,7 +188,7 @@ def test_marker_message(testdir):
     result.stdout.fnmatch_lines(
         [
             "@pytest.mark.count_queries: "
-            "Mark the test as to have their queries counted."
+            "Mark the test as to have their database query counted."
         ]
     )
 


### PR DESCRIPTION
- [x] Renamed the marker description to be more meaningful about was it does.
- [x] Fixed a typo in the readme file.
- [x] Added help texts for named parameters in the cli.
- [x] Fixed the wrong help text saying it is taking an integer when it actually expects a file path.
- [x] Users can now mark tests without having the `count_queries` fixture injected automatically if a custom order or manual usage is needed.
- [x] Added a better filtering of unwanted keywords in humanization of test names. It now handles test cases names inside modules (dotted import names).
- [x] Added a `backup` command to `django-queries` to make it easier of making a copy of the current results.

## Changes Checklist
<!-- Please keep this section and check what's true -->
- [x] The changes were tested (manually)
- [x] The changes are tested automatically (pytest)
- [x] The changes are optimized and clean
- [x] The changes are documented:
  - [x] The code is documented
  - [x] The readme is up to date
  - [x] The documentation (readthedocs) is up to date and tested
