### PR TITLE
xdist is now supported by the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
          && django=https://github.com/django/django/archive/master.tar.gz \
          || django="django${DJANGO}"
     fi
-  - pip install tox-travis codecov coverage $django
+  - pip install pytest-xdist tox-travis codecov coverage $django
   - >
     if [ -n "$TEST_PYPI" ]; then
       if [ -n "$TRAVIS_TAG" ]; then


### PR DESCRIPTION
This is unfortunately a retrogradation until we figure for a better way to handle the communication between xdist slaves and master. Especially as we are doing many `open()` calls.

For now the support of xdist is really important. Improvement can and will be done; anybody with a better experience with xdist is free to open any pull request or suggestions on how to improve the plugin!

Closes #36.

## Changes Checklist
<!-- Please keep this section and check what's true -->
- [x] The changes were tested (manually)
- [x] The changes are tested automatically (pytest)
- [ ] The changes are optimized and clean
- [ ] The changes are documented:
  - [ ] The code is documented
  - [ ] The readme is up to date
  - [ ] The documentation (readthedocs) is up to date and tested
