### PR TITLE
buid: add publish PyPI & prepare 1.3.0rc1 release

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,87 @@
+name: Publish to PyPI
+on:
+  release:
+    types:
+      - released
+      - prereleased
+
+  workflow_dispatch:
+    inputs:
+      pypi_repo:
+        description: Which PyPI repository to use
+        required: true
+        type: choice
+        options: ["pypi", "testpypi"]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          python-version: ${{ steps.setup-python.outputs.python-version }}
+          version: "0.10.7"
+          # hash for uv-x86_64-unknown-linux-gnu.tar.gz.sha256
+          # (from https://github.com/astral-sh/uv/releases)
+          checksum: "9ac6cee4e379a5abfca06e78a777b26b7ba1f81cb7935b97054d80d85ac00774"
+
+      - name: Build source distributions and wheels
+        run: uv build -o ./dist
+
+      - name: Upload Build
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: "dist"
+          path: "dist/"
+          if-no-files-found: error
+          retention-days: 5
+
+  publish:
+    runs-on: ubuntu-24.04
+    environment: publish-pypi
+
+    needs:
+      - build
+
+    permissions:
+      id-token: write # Required for PyPI trusted publishing
+
+    steps:
+      - name: Download source distributions and wheels
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to PyPI
+        if: >-
+          github.event_name == 'release' 
+            || (
+                github.event_name == 'workflow_dispatch'
+                && github.event.inputs.pypi_repo == 'pypi'
+            )
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+      - name: Publish to TestPyPI
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && github.event.inputs.pypi_repo == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-v1.3.0 - Unreleased
-+++++++++++++++++++
+v1.3.0 - March 1st 2026
++++++++++++++++++++++++
 
 - Switched project to uv and pyproject.toml
 - Switched build system from Travis CI to GitHub Actions

--- a/README.md
+++ b/README.md
@@ -12,13 +12,10 @@
     <a href='https://pypi.python.org/pypi/pytest-django-queries'>
       <img src='https://img.shields.io/pypi/v/pytest-django-queries.svg' alt='Version' />
     </a>
-    <a href="https://pypi.org/project/pytest-django-queries/1.2rc1/">
-      <img src="https://img.shields.io/badge/pypi%20unstable-v1.2rc1-FF0000.svg" alt="Latest Unstable on pypi">
-    </a>
   </p>
   <p>
-    <a href='https://github.com/NyanKiyoshi/pytest-django-queries/compare/v1.2.0...master'>
-      <img src='https://img.shields.io/github/commits-since/NyanKiyoshi/pytest-django-queries/v1.2.0.svg' alt='Commits since latest release' />
+    <a href='https://github.com/NyanKiyoshi/pytest-django-queries/compare/v1.3.0rc1...master'>
+      <img src='https://img.shields.io/github/commits-since/NyanKiyoshi/pytest-django-queries/v1.3.0rc1.svg' alt='Commits since latest release' />
     </a>
     <a href='https://pypi.python.org/pypi/pytest-django-queries'>
       <img src='https://img.shields.io/pypi/pyversions/pytest-django-queries.svg' alt='Supported versions' />

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,7 @@ addition of in the changelog.
 - [ ] Bump the major, minor or patch version number
 
 ## Bumping the version
-- [ ] Make sure to bump the `setup.py`'s version to the correct newest version.
+- [ ] Make sure to bump the version in `pyproject.toml` to the correct newest version.
 - [ ] Update the `README.md` file's comparison tag version (look for `Commits since latest release`).
 - [ ] Commit with the message "Bump version for new release" and push it to a new branch
 - [ ] Prepare the final changelog and notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "pytest-django-queries"
-version = "1.2.0"
+version = "1.3.0rc1"
 description = "Generate performance reports from your django database performance tests."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "pytest-django-queries"
-version = "1.2.0"
+version = "1.3.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifultable" },


### PR DESCRIPTION
Changes:
- Added a publish to PyPI workflow (using trusted publishers & attestations)
- Bumped the project version to v1.3.0rc1

## Changes Checklist
<!-- Please keep this section and check what's true -->
- [x] The changes were tested (manually)
- [x] The changes are tested automatically (pytest)
- [x] The changes are optimized and clean
- [x] The changes are documented:
  - [x] The code is documented
  - [x] The readme is up to date
  - [x] The documentation (readthedocs) is up to date and tested
