### PR TITLE
fix(build): omit codecov token for dependabot

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,7 +107,10 @@ jobs:
     if: >-
       ${{
           github.ref == 'refs/heads/main'
-          || github.event.pull_request.head.repo.full_name == 'NyanKiyoshi/pytest-django-queries'
+          || (
+              github.event.pull_request.head.repo.full_name == 'NyanKiyoshi/pytest-django-queries'
+              && github.actor != 'dependabot[bot]'
+          )
       }}
     runs-on: ubuntu-latest
     environment: codecov
@@ -141,10 +144,10 @@ jobs:
   upload-coverage-forks:
     if: >-
       ${{
-        ! (
-            github.ref == 'refs/heads/main'
-            || github.event.pull_request.head.repo.full_name == 'NyanKiyoshi/pytest-django-queries'
-        )
+        (
+          github.ref != 'refs/heads/main'
+          && github.event.pull_request.head.repo.full_name != 'NyanKiyoshi/pytest-django-queries'
+        ) || github.actor == 'dependabot[bot]'
       }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,7 +132,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           directory: ./coverage/reports/
           fail_ci_if_error: true
@@ -170,7 +170,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           directory: ./coverage/reports/
           fail_ci_if_error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,11 +106,10 @@ jobs:
   upload-coverage-non-forks:
     if: >-
       ${{
-          github.ref == 'refs/heads/main'
-          || (
-              github.event.pull_request.head.repo.full_name == 'NyanKiyoshi/pytest-django-queries'
-              && github.actor != 'dependabot[bot]'
-          )
+          (
+            github.ref == 'refs/heads/main'
+            || github.event.pull_request.head.repo.full_name == 'NyanKiyoshi/pytest-django-queries'
+          ) && github.actor != 'dependabot[bot]'
       }}
     runs-on: ubuntu-latest
     environment: codecov
@@ -144,10 +143,12 @@ jobs:
   upload-coverage-forks:
     if: >-
       ${{
-        (
-          github.ref != 'refs/heads/main'
-          && github.event.pull_request.head.repo.full_name != 'NyanKiyoshi/pytest-django-queries'
-        ) || github.actor == 'dependabot[bot]'
+        ! (
+          (
+            github.ref == 'refs/heads/main'
+            || github.event.pull_request.head.repo.full_name == 'NyanKiyoshi/pytest-django-queries'
+          ) && github.actor != 'dependabot[bot]'
+        )
       }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Removes the token usage when PR is coming from dependabot as it is not running inside a fork therefore weren't properly detecting that secrets are inaccessible

<!-- Please reference all the relevant issues -->

## Changes Checklist
<!-- Please keep this section and check what's true -->
- [ ] The changes were tested (manually)
- [ ] The changes are tested automatically (pytest)
- [ ] The changes are optimized and clean
- [ ] The changes are documented:
  - [ ] The code is documented
  - [ ] The readme is up to date
  - [ ] The documentation (readthedocs) is up to date and tested
